### PR TITLE
Catch PHP 7 errors in Resque_Worker::perform() and adhere to PSR-3 when logging exceptions

### DIFF
--- a/lib/Resque/Failure.php
+++ b/lib/Resque/Failure.php
@@ -29,6 +29,20 @@ class Resque_Failure
 	}
 
 	/**
+	 * Create a new failed job on the backend from PHP 7 errors.
+	 *
+	 * @param object $payload        The contents of the job that has just failed.
+	 * @param \Error $exception  The PHP 7 error generated when the job failed to run.
+	 * @param \Resque_Worker $worker Instance of Resque_Worker that was running this job when it failed.
+	 * @param string $queue          The name of the queue that this job was fetched from.
+	 */
+	public static function createFromError($payload, Error $exception, Resque_Worker $worker, $queue)
+	{
+		$backend = self::getBackend();
+		new $backend($payload, $exception, $worker, $queue);
+	}
+
+	/**
 	 * Return an instance of the backend for saving job failures.
 	 *
 	 * @return object Instance of backend object.

--- a/lib/Resque/Job.php
+++ b/lib/Resque/Job.php
@@ -220,12 +220,21 @@ class Resque_Job
 		));
 
 		$this->updateStatus(Resque_Job_Status::STATUS_FAILED);
-		Resque_Failure::create(
-			$this->payload,
-			$exception,
-			$this->worker,
-			$this->queue
-		);
+		if ($exception instanceof Error) {
+			Resque_Failure::createFromError(
+				$this->payload,
+				$exception,
+				$this->worker,
+				$this->queue
+			);
+		} else {
+			Resque_Failure::create(
+				$this->payload,
+				$exception,
+				$this->worker,
+				$this->queue
+			);
+		}
 		Resque_Stat::incr('failed');
 		Resque_Stat::incr('failed:' . $this->worker);
 	}

--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -240,7 +240,12 @@ class Resque_Worker
 			$job->perform();
 		}
 		catch(Exception $e) {
-			$this->logger->log(Psr\Log\LogLevel::CRITICAL, '{job} has failed {stack}', array('job' => $job, 'stack' => $e));
+			$this->logger->log(Psr\Log\LogLevel::CRITICAL, '{job} has failed {exception}', array('job' => $job, 'exception' => $e));
+			$job->fail($e);
+			return;
+		}
+		catch(Error $e) {
+			$this->logger->log(Psr\Log\LogLevel::CRITICAL, '{job} has failed {exception}', array('job' => $job, 'exception' => $e));
 			$job->fail($e);
 			return;
 		}


### PR DESCRIPTION
Pulling in this PR to improve the logging